### PR TITLE
Volume watcher

### DIFF
--- a/modules/commandTxs.js
+++ b/modules/commandTxs.js
@@ -767,7 +767,6 @@ function amount(param) {
 }
 
 function volume(params) {
-  console.log(params);
   const coin1 = params[1].toUpperCase();
   const coin2 = params[3].toUpperCase();
   if (

--- a/modules/commandTxs.js
+++ b/modules/commandTxs.js
@@ -766,6 +766,61 @@ function amount(param) {
   };
 }
 
+function volume(params) {
+  console.log(params);
+  const coin1 = params[1].toUpperCase();
+  const coin2 = params[3].toUpperCase();
+  if (
+    !coin1 || !coin2 || coin1 === coin2 ||
+    (![config.coin1, config.coin2].includes(coin1)) || (![config.coin1, config.coin2].includes(coin2))
+  ) {
+    return {
+      msgNotify: '',
+      msgSendBack: `Incorrect volume coins. Config is set to trade ${config.pair} pair. Example: */volume 0 ${config.coin1} 50000 ${config.coin2}*.`,
+      notifyType: 'log',
+    };
+  }
+
+  const coin1Amount = +params[0];
+  if (!utils.isPositiveOrZeroNumber(coin1Amount)) {
+    return {
+      msgNotify: '',
+      msgSendBack: `Incorrect ${coin1} amount: ${coin1Amount}. Example: */volume 0 ${config.coin1} 50000 ${config.coin2}*.`,
+      notifyType: 'log',
+    };
+  }
+
+  const coin2Amount = +params[2];
+  if (!utils.isPositiveOrZeroNumber(coin2Amount)) {
+    return {
+      msgNotify: '',
+      msgSendBack: `Incorrect ${coin2} amount: ${coin2Amount}. Example: */volume 0 ${config.coin1} 50000 ${config.coin2}*.`,
+      notifyType: 'log',
+    };
+  }
+
+  tradeParams.mm_targetVolumeCoin1 = coin1Amount;
+  tradeParams.mm_targetVolumeCoin2 = coin2Amount;
+
+  let infoString = ` to pause trading when reaching a 24 hours volume of`;
+
+  if(coin1Amount > 0 && coin2Amount > 0) {
+    infoString += ` ${coin1Amount} ${config.coin1} or ${coin2Amount} ${config.coin2} for ${config.pair} pair.`;
+  } else if(coin1Amount > 0) {
+    infoString += ` ${coin1Amount} ${config.coin1}`;
+  } else {
+    infoString += ` ${coin2Amount} ${config.coin2}`;
+  }
+
+  infoString += ` for ${config.pair} pair.`;
+
+  return {
+    msgNotify: `${config.notifyName} is set ${infoString}`,
+    msgSendBack: `Set ${infoString}`,
+    notifyType: 'log',
+  };
+}
+
 function interval(param) {
   const val = (param[0] || '').trim();
   if (!val || !val.length || (val.indexOf('-') === -1)) {
@@ -2273,6 +2328,7 @@ const commands = {
   deposit,
   make,
   y,
+  volume,
   saveConfig: utils.saveConfig,
 };
 

--- a/modules/commandTxs.js
+++ b/modules/commandTxs.js
@@ -1747,6 +1747,17 @@ async function getOrdersInfo(accountNo = 0, tx = {}, pair) {
 
     ordersByType.openOrdersCount = openOrders.length;
     ordersByType.unkLength = openOrders.length - ordersByType['all'].allOrders.length;
+
+    if(ordersByType.unkLength > 0) {
+      // get all open orders ids
+      const openOrdersIds = openOrders.map((order) => order.orderId);
+      // get all known orders ids
+      const knownOrdersIds = ordersByType['all'].allOrders.map((order) => order._id);
+
+      const difference = openOrdersIds.filter(x => !knownOrdersIds.includes(x));
+      // concatenate array of ids into string
+      ordersByType.unkString = difference.join(', ');
+    }
     if (previousOrders?.[accountNo]?.[tx.senderId]?.[pairObj?.pair]?.unkLength) {
       diff = ordersByType.unkLength - previousOrders[accountNo][tx.senderId][pairObj.pair].unkLength;
       sign = diff > 0 ? '+' : '−';
@@ -1789,7 +1800,7 @@ async function getOrdersInfo(accountNo = 0, tx = {}, pair) {
     output += '\n\n' + `No open orders in my database.`;
   }
 
-  output += `\n\nOrders which are not in my database (Unknown orders): ${ordersByType.unkLength}${diffStringUnknownOrdersCount}.`;
+  output += `\n\nOrders which are not in my database (Unknown orders): ${ordersByType.unkLength}${diffStringUnknownOrdersCount}. Ids: ${ordersByType.unkString}.`;
 
   previousOrders[accountNo][tx.senderId] = {};
   previousOrders[accountNo][tx.senderId][pairObj.pair] = ordersByType;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adamant-tradebot",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "ADAMANT Trading and Market-making bot",
   "main": "index.js",
   "scripts": {

--- a/trade/mm_trader.js
+++ b/trade/mm_trader.js
@@ -175,7 +175,7 @@ module.exports = {
           order2 = await takerApi.placeOrder(type, config.pair, price, coin1Amount, 1, null);
           if (order2 && order2.orderId) {
             output = `${type} ${coin1Amount.toFixed(coin1Decimals)} ${config.coin1} for ${coin2Amount.toFixed(coin2Decimals)} ${config.coin2} at ${price.toFixed(coin2Decimals)} ${config.coin2}`;
-            log.info(`Market-making: Successfully executed mm-order to ${output}. Action: executeInSpread.`);
+            log.info(`Market-making: Successfully executed mm-order ${order1.orderId} and ${order2.orderId} to ${output}. Action: executeInSpread.`);
             order.update({
               isProcessed: true,
               isExecuted: true,
@@ -222,7 +222,7 @@ module.exports = {
           await order.save();
 
           output = `${type} ${coin1Amount.toFixed(coin1Decimals)} ${config.coin1} for ${coin2Amount.toFixed(coin2Decimals)} ${config.coin2} at ${price.toFixed(coin2Decimals)} ${config.coin2}`;
-          log.info(`Market-making: Successfully executed mm-order to ${output}. Action: executeInOrderBook.`);
+          log.info(`Market-making: Successfully executed mm-order ${order1.orderId} to ${output}. Action: executeInOrderBook.`);
 
         } else { // if order1
           log.warn(`Market-making: Unable to execute mm-order with params: ${orderParamsString}. Action: executeInOrderBook. No order id returned.`);

--- a/trade/settings/tradeParams_lbank.js
+++ b/trade/settings/tradeParams_lbank.js
@@ -23,4 +23,6 @@ module.exports = {
   'mm_priceWatcherSource': '#',
   'mm_priceWatcherSourcePolicy': 'smart',
   'mm_priceWatcherAction': 'fill',
+  'mm_targetVolumeCoin1': 0,
+  'mm_targetVolumeCoin2': 0
 };


### PR DESCRIPTION
Added new functionality to pause MM orders when a certain volume on the pair is reached. This includes a new command: "/volume [AMOUNT] [COIN1] [AMOUNT] [COIN2]". If AMOUNT is 0, then the volume limit is disabled. If both AMOUNT values are set, MM will be paused when volume is reached in COIN1 or COIN2. Frequency for checking the volume is equal to the MM trading interval set with "/interval"